### PR TITLE
Configure Flask app for Render deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn main:app

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask, render_template, redirect, url_for, flash, abort
 from flask_bootstrap import Bootstrap
 from flask_ckeditor import CKEditor
@@ -11,7 +13,7 @@ from functools import wraps
 from sqlalchemy.orm import relationship
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = '8BYkEfBA6O6donzWlSihBXox7C0sKR6b'
+app.config['SECRET_KEY'] = os.environ.get("SECRET_KEY", "dev-secret-key")
 ckeditor = CKEditor(app)
 Bootstrap(app)
 
@@ -21,7 +23,7 @@ app.config['AVATARS_GRAVATAR_RATING'] = 'g'
 avatars = Avatars(app)
 
 ##CONNECT TO DB
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///blog.db'
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get("DATABASE_URL", "sqlite:///blog.db")
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ urllib3==1.25.10
 visitor==0.1.3
 Werkzeug==1.0.1
 WTForms==2.3.3
+gunicorn


### PR DESCRIPTION
## Summary
- add a Procfile to launch the app with gunicorn on Render
- update configuration to source the secret key and database URL from environment variables with local fallbacks
- include gunicorn in the Python requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e11f7e241c8333814e19f1ce9104ff